### PR TITLE
Feature: players avatar preview on player page and peers section.

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE player
+    ADD COLUMN avatar text,
+    ADD COLUMN avatarmedium text,
+    ADD COLUMN avatarfull text;

--- a/schema.sql
+++ b/schema.sql
@@ -328,6 +328,3 @@ CREATE TABLE IF NOT EXISTS chat (
 -- Reverse index for lookups by steamid64
 -- Don't index NULLs since we don't generally want to look them up.
 CREATE INDEX IF NOT EXISTS chat_steamid64 ON chat (steamid64, logid) WHERE steamid64 NOTNULL;
-
---
--- CREATE EXTENSION btree_gin;

--- a/schema.sql
+++ b/schema.sql
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS map (
 	map TEXT NOT NULL UNIQUE
 );
 
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
 CREATE INDEX IF NOT EXISTS map_names ON map USING gin (map gin_trgm_ops);
 
 CREATE TABLE IF NOT EXISTS log (
@@ -100,7 +101,10 @@ CREATE TABLE IF NOT EXISTS name (
 CREATE INDEX IF NOT EXISTS name_fts ON name USING GIN (to_tsvector('english', name));
 
 CREATE TABLE IF NOT EXISTS player (
-	steamid64 BIGINT PRIMARY KEY
+	steamid64 BIGINT PRIMARY KEY,
+    avatar TEXT,
+    avatarmedium TEXT,
+    avatarfull TEXT
 );
 
 CREATE TABLE IF NOT EXISTS player_stats (
@@ -324,3 +328,6 @@ CREATE TABLE IF NOT EXISTS chat (
 -- Reverse index for lookups by steamid64
 -- Don't index NULLs since we don't generally want to look them up.
 CREATE INDEX IF NOT EXISTS chat_steamid64 ON chat (steamid64, logid) WHERE steamid64 NOTNULL;
+
+--
+-- CREATE EXTENSION btree_gin;

--- a/sql.py
+++ b/sql.py
@@ -4,6 +4,7 @@
 import flask
 import os
 import psycopg2, psycopg2.extras
+import psycopg2.extensions
 
 from steamid import SteamID
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -114,3 +114,8 @@ td.left {
 	float: left;
 	padding: 5px;
 }
+
+dl.totals {
+	margin-left: 194px;
+	margin-top: -160px;
+}

--- a/templates/player/base.html
+++ b/templates/player/base.html
@@ -8,7 +8,8 @@
 	<h1><a href="http://steamcommunity.com/profiles/{{ g.player['steamid64'] }}">
 			{{ g.player['name'] }}
 	</a></h1>
-	<dl>
+    <img src="{{ g.player['avatarfull'] }}">
+	<dl class="totals">
 		<dt><abbr title="Wins-Losses-Ties">W-L-T</abbr></dt>
 		<dd>{{ wlt(g.player['wins'], g.player['losses'], g.player['ties']) }}</dd>
 		<dt><abbr title="Ties count as 0.5 wins">Winrate</abbr></dt>

--- a/templates/player/peers.html
+++ b/templates/player/peers.html
@@ -9,6 +9,7 @@
 	{{ navigation(peers, "{}?".format(request.path), limit, offset) }}
 {% macro header() %}
 <tr>
+    <th>Avatar</th>
 	<th>Player</th>
 	<th>Logs With</th>
 	<th><abbr title="Winrate With, ties count as 0.5 wins">
@@ -31,6 +32,9 @@
 		<tbody>
 			{% for peer in peers %}
 			<tr>
+                <td>
+                    <img src="{{ peer['avatar'] }}">
+                </td>
 				<td class="left">
 					<a href="{{ url_for('.overview', steamid=peer['steamid64']) }}">
 						{{ peer['name'] }}


### PR DESCRIPTION
Hi, 

I added support for avatars in postgres schema (new fields in player table) and added them to templates/api endpoints.

Also i wrote tool for quering steam API for avatars, i recommend using it with cron (f. e. `0 3 * * * /path/to/dir/pfpcrawler`). It requires .env file, there is template in [repo](https://github.com/CondensedTea/steam_avatar_crawler) and compiled binary in releases.

If accepted, closes #32.

Alex Tyshkevich.