### PR TITLE
Add bot detection bypass to prevent false bot flags

### DIFF
--- a/test/site_test.py
+++ b/test/site_test.py
@@ -556,3 +556,11 @@ def test_ua_chrome(client, version, agent):
 @pytest.mark.parametrize('version,agent', chrome)
 def test_ua_chrome_without_sec(client, version, agent):
     assert client.get("/about", headers={ "User-Agent": agent }).status_code == 403
+
+@pytest.mark.parametrize('version,agent', chrome)
+def test_ua_chrome_with_bypass(client, version, agent):
+    headers = {
+        "User-Agent": agent,
+        "X-Not-A-Bot": "true", 
+    }
+    assert client.get("/about", headers=headers).status_code == 200

--- a/trends/site/templates/api.html
+++ b/trends/site/templates/api.html
@@ -128,6 +128,17 @@
 	automatically lift after one hour. Static content is not rate-limited.
 	</p>
 
+	<h3>403 errors</h3>
+	<p>
+	To prevent AI/bot scrapers from flooding the API, if a request's {{ pre("User-Agent") }} header is set to
+	Chrome/Chromium and no {{ pre("Sec-CH-UA") }} header is provided, the API will assume the request originated
+	from a bot/scraper and will return a 403. If you trigger too many 403 errors, your IP will be
+	blacklisted. If for whatever reason your {{ pre("User-Agent") }} header is forced to be Chrome/Chromium
+	and you cannot include the {{ pre("Sec-CH-UA") }} header in your request &#40;for example if you're making
+	the request from a Chromium browser extension&#41;, you may include the {{ pre("X-Not-A-Bot") }} header to
+	bypass the scraper detection.
+	</p>
+
 	<h2 id="params">Parameters</h2>
 	<p>
 	This section documents parameters with shared semantics across multiple endpoints.

--- a/trends/site/wsgi.py
+++ b/trends/site/wsgi.py
@@ -171,6 +171,9 @@ def user_agent_filter():
     if ch := flask.request.headers.get("Sec-Fetch-Mode"):
         return
 
+    if bypass := flask.request.headers.get("X-Not-A-Bot"):
+        return
+
     return "", 403
 
 def set_validators(resp):


### PR DESCRIPTION
Adds custom header X-Not-A-Bot to bypass bot/scraper detection for legit requests originating from Chromium based browsers (specifically from browser extensions). This would prevent legitimate requests from receiving error 403 while still blocking most if not all scraper requests. Also update API docs to give more info on 403 errors and this new header, talking about what exactly causes a 403 error to be returned and how it can be avoided. This should help people using the API for the first time who may have trouble with 403 errors due to Chrome/Chromium.

Signed-off-by: Mason Burns masonatortf@gmail.com