### PR TITLE
Add API endpoint for fetching single logs

### DIFF
--- a/test/site_test.py
+++ b/test/site_test.py
@@ -61,13 +61,13 @@ class RandomEndpointSelector:
             return True
         return False
 
-def create_crawler(client, initial=('/',), **kwargs):
+def create_crawler(client, initial=('/',), allow_404=False, **kwargs):
     return Crawler(
         client=client,
         initial_paths=initial,
         path_attrs=('href', 'src'),
         rules=(
-            Rule('a', '/.*', 'GET', Request()),
+            Rule('a', '/.*', 'GET', Allow((404,)) if allow_404 else Request()),
             Rule('a', '.*player.*', 'GET', Allow((404,))),
             Rule('link', '/.*', 'GET', Request()),
             Rule('img', '/.*', 'GET', Request()),
@@ -258,6 +258,46 @@ def test_dupes(connection):
     cur.execute("SELECT logid, duplicate_of FROM log WHERE duplicate_of NOTNULL")
     assert { logid: duplicate_of for logid, duplicate_of in cur } == duplicates
 
+LOG_VALID_KEYS = {
+    'demoid',
+    'duplicate_of',
+    'duration',
+    'format',
+    'league',
+    'logid',
+    'map',
+    'matchid',
+    'time',
+    'title',
+    'updated',
+}
+
+def test_api_log(client):
+    def get(id):
+        resp = client.get(f"api/v1/log/{id}")
+        assert resp.status_code == 200
+        resp = resp.json
+        return resp['summary']
+
+    logs = client.get("api/v1/logs", query_string={'view': 'players'}).json['logs']
+
+    for log in logs:
+        log2 = get(log['logid'])
+        # every key in log should have the same value in log2 (if it has a value)
+        for key in LOG_VALID_KEYS:
+            if log[key] is None:
+                assert log2[key] is None
+            else:
+                assert log2[key] == log[key]
+
+        assert log2['red_score'] == log['red']['score']
+        assert log2['blue_score'] == log['blue']['score']
+
+        assert 'team1_is_red' not in log2
+
+    # this log shouldn't exist and should always 404
+    assert client.get("api/v1/log/127").status_code == 404
+
 def test_api_logs(client):
     def get(**params):
         resp = client.get("api/v1/logs", query_string=params)
@@ -266,26 +306,13 @@ def test_api_logs(client):
         return resp['logs'], resp['next_page']
 
     logs, next_page = get()
-    valid_keys = {
-        'demoid',
-        'duplicate_of',
-        'duration',
-        'format',
-        'league',
-        'logid',
-        'map',
-        'matchid',
-        'time',
-        'title',
-        'updated',
-    }
 
     updated_pivot = 0
     for log in logs:
         logid = log['logid']
         assert logid is not None
 
-        assert set(log.keys()) == valid_keys
+        assert set(log.keys()) == LOG_VALID_KEYS
 
         unupdated = True
         if logid in linked_demos:
@@ -333,7 +360,7 @@ def test_api_logs(client):
     assert get(offset=len(logs)) == ([], None)
 
     for log in get(view='players')[0]:
-        assert set(log.keys()) == valid_keys | { 'red', 'blue' }
+        assert set(log.keys()) == LOG_VALID_KEYS | { 'red', 'blue' }
         for team in ('red', 'blue'):
             team = log[team]
             if log['league'] is None:
@@ -398,7 +425,7 @@ def check_purge(db, cache, extra=()):
 
     # populate the cache with old data
     client = create_app(db, cache).test_client()
-    crawler = create_crawler(client, initial=("/", *extra))
+    crawler = create_crawler(client, initial=("/", *extra), allow_404=True)
     crawler.crawl()
 
     # mutate the database
@@ -419,7 +446,8 @@ def check_purge(db, cache, extra=()):
 
     # collect the cached data
     initial = [node.path for node in crawler.graph.map.values() if node.requested]
-    crawler = create_crawler(client, initial=initial, check_response_handlers=(store,))
+    crawler = create_crawler(client, initial=initial, allow_404=True,
+                             check_response_handlers=(store,))
     crawler.crawl()
 
     # make sure the uncached data matches the cached data
@@ -549,7 +577,7 @@ chrome = (
 def test_ua_chrome(client, version, agent):
     headers = {
         "User-Agent": agent,
-        "Sec-Fetch-Mode": "navigate", 
+        "Sec-Fetch-Mode": "navigate",
     }
     assert client.get("/about", headers=headers).status_code == 200
 

--- a/trends/site/api.py
+++ b/trends/site/api.py
@@ -7,6 +7,7 @@ import werkzeug.exceptions
 from .. import cache
 from .common import get_logs, search_players, logs_last_modified
 from .util import get_db, get_mc, get_pagination, last_modified, view_updated
+from .root import get_log
 
 api = flask.Blueprint('api', __name__)
 
@@ -27,6 +28,20 @@ def next_page(rows):
     if len(rows) == limit:
         args['offset'] = offset + limit
         return flask.url_for(flask.request.endpoint, **args)
+
+@api.route('/log/<int:logid>')
+def log(logid):
+    log = get_log(get_mc(), logid)
+
+    if not log:
+        return flask.abort(404)
+
+    if resp := last_modified(log['summary']['updated'], log['version'], weak=True):
+        return resp
+
+    summary = log['summary']
+    del summary['team1_is_red']
+    return flask.jsonify(summary=summary)
 
 @api.route('/logs')
 def logs():

--- a/trends/site/templates/api.html
+++ b/trends/site/templates/api.html
@@ -12,7 +12,7 @@
 {% macro apidef(endpoint, version=1, method="GET") %}
 <h3 id="api-{{method }}-{{ endpoint }}-v{{ version }}">
 	{{ method }}
-	<a href="{{ url_for('api.{}'.format(endpoint)) }}">{{ pre(apipath(endpoint, version)) }}</a>
+	{{ pre(apipath(endpoint, version)) }}
 </h3>
 {% endmacro %}
 {% macro apiref(endpoint, version=1, method="GET") %}
@@ -255,6 +255,14 @@
 	<a href="https://demos.tf">demos.tf</a>.
 	</p>
 
+	{{ fielddef('duplicate_of') }}
+	<p>
+	An array of {{ fieldref('logid') }}s that this log is a duplicate of (which
+	may themselves be duplicates), if any. Duplicate logs are typically combined
+	or otherwise duplicated versions of other logs. They should not be used for
+	statistical purposes.
+	</p>
+
 	{{ fielddef('format') }}
 	<p>
 	A game format as one of the following values:
@@ -298,6 +306,14 @@
 	A relative URL to the next page of results. If the number of returned results is equal
 	to the {{ paramref('limit') }}, then this field may be non-{{ pre("null") }} even if the
 	next page is empty.
+	</p>
+
+	{{ fielddef('score') }}
+	<p>
+	The points scored by this team. This is the raw number as reported on the scoreboard, and does
+	not reflect rounds played. For instance, if there is a stalemate due to the round timer this
+	will not be reflected in either score, and if there is a stalemate due to the time limit this
+	will be an extra point for the winning team.
 	</p>
 
 	{{ fielddef('steamid64') }}
@@ -397,11 +413,7 @@
 			<dt>{{ pre('demoid') }} : option(number)</dt>
 			<dd>The linked {{ fieldref('demoid') }}, if any</dd>
 			<dt>{{ pre('duplicate_of') }} : option(array(number))</dt>
-			<dd>
-			An array of {{ fieldref('logid') }}s that this log is a duplicate of (which
-			may themselves be duplicates), if any. Duplicate logs are typically combined
-			or otherwise duplicated versions of other logs. They should not be used for
-			statistical purposes.
+			<dd>Logs that this is a {{ fieldref('duplicate_of') }}, if any.
 			</dd>
 			<dt>{{ pre('duration') }} : number</dt>
 			<dd>The duration of the log, in seconds</dd>
@@ -452,11 +464,7 @@
 				</dd>
 				<dt>{{ pre('score') }} : number</dt>
 				<dd>
-				The points scored by this team. This is the raw number as reported
-				on the scoreboard, and does not reflect rounds played. For instance,
-				if there is a stalemate due to the round timer this will not be
-				reflected in either score, and if there is a stalemate due to the
-				time limit this will be an extra point for the winning team.
+				This team's {{ fieldref('score') }}.
 				</dd>
 			</dl>
 			</p>
@@ -465,6 +473,58 @@
 		</p>
 		<dt>{{ pre('next_page') }} : option(string)<dt>
 		<dd>The {{ fieldref('next_page') }} of logs, if any</dd>
+	</dl>
+
+	{{ apidef('log/<logid>') }}
+	<p>
+	The {{ pre('/v1/log/<logid>') }} endpoint provides log information similar to what is presented
+	on individual logs' pages. For example, <a href="{{ url_for('api.log', logid='3302982') }}">
+	{{ pre('/v1/log/3302982') }}</a> returns information about
+	<a href="{{ url_for('root.log', logids=3302982) }}">Log 3302982</a>.
+	</p>
+
+	<h4>Arguments</h4>
+	<p>
+	The {{ pre('/v1/log/<logid>') }} endpoint requires the following arguments:
+	<ul>
+	<li>{{ fieldref('logid') }}</li>
+	</ul>
+
+	<h4>Response</h4>
+	<dl>
+		<dt>{{ pre('summary') }} : object<dt>
+		<dd>
+		<p>
+		The returned object contains the following:
+		<dl>
+			<dt>{{ pre('blue_score') }} : number</dt>
+			<dd>The blue team's {{ fieldref('score') }}.</dd>
+			<dt>{{ pre('demoid') }} : option(number)</dt>
+			<dd>The linked {{ fieldref('demoid') }}, if any</dd>
+			<dt>{{ pre('duplicate_of') }} : option(array(number))</dt>
+			<dd>Logs that this is a {{ fieldref('duplicate_of') }}, if any.</dd>
+			<dt>{{ pre('duration') }} : number</dt>
+			<dd>The duration of the log, in seconds</dd>
+			<dt>{{ pre('format') }} : option(string)</dt>
+			<dd>The {{ fieldref('format') }} of the log</dd>
+			<dt>{{ pre('league') }} : option(string)</dt>
+			<dd>The {{ fieldref('league') }} of the linked match, if any</dd>
+			<dt>{{ pre('logid') }} : number</dt>
+			<dd>The {{ fieldref('logid') }} of the log</dd>
+			<dt>{{ pre('map') }} : string</dt>
+			<dd>The (user-supplied) map this log was played on</dd>
+			<dt>{{ pre('matchid') }} : option(number)</dt>
+			<dd>The {{ fieldref('matchid') }} of the linked match, if any</dd>
+			<dt>{{ pre('red_score') }} : number</dt>
+			<dd>The red team's {{ fieldref('score') }}.</dd>
+			<dt>{{ pre('time') }} : number</dt>
+			<dd>The upload {{ fieldref('time') }} of the log</dd>
+			<dt>{{ pre('title') }} : string</dt>
+			<dd>The (user-supplied) title for the log</dd>
+			<dt>{{ pre('updated') }} : number</dt>
+			<dd>The {{ fieldref('time') }} this object was last modified</dd>
+		</dl>
+		</p>
 	</dl>
 	</div>
 {% endblock %}


### PR DESCRIPTION
Adds the API endpoint /v1/log/<logid>, making it much easier to fetch info 
on a log with a known ID. Previously, to get info on a specific log, you 
would need to get the timestamp of the log and at least one player in the 
log, then you would have to search within a specific time range for logs 
that player played. This is quite inconvenient for finding single logs, and 
requires the database to be searched before a result can be returned. With 
this new endpoint, you simply provide the log ID and it returns info on 
that log. This endpoint also has the same view=players functionality as the 
logs endpoint.
Also adds a few test cases for the new endpoint.

Signed-off-by: Mason Burns [masonatortf@gmail.com](mailto:masonatortf@gmail.com)